### PR TITLE
(SIMP-20) Add support for custom env and hiera

### DIFF
--- a/skeleton/spec/spec_helper.rb
+++ b/skeleton/spec/spec_helper.rb
@@ -24,12 +24,46 @@ default_hiera_config =<<-EOM
 :yaml:
   :datadir: "stub"
 :hierarchy:
-  # This is a variable that you can set in your test classes to ensure that the
-  # targeted YAML file gets loaded in the fixtures.
-  - "%{spec_title}"
+  - "%{custom_hiera}"
   - "%{module_name}"
   - "default"
 EOM
+
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
   FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
@@ -40,6 +74,20 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
 end
 
 RSpec.configure do |c|
+  # If nothing else...
+  c.default_facts = {
+    :path                      => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+    :fqdn                      => 'rspec.test.localdomain',
+    :operatingsystem           => 'RedHat',
+    :operatingsystemrelease    => '6.6',
+    :operatingsystemmajrelease => '6',
+    :osfamily                  => 'RedHat',
+    :memorysize                => '2 GB',
+    # Watch out! If stringify_facts is false, you need to change this!
+    :processorcount            => '4',
+    :concat_basedir            => '/tmp'
+  }
+
   c.mock_framework = :rspec
   c.mock_with :mocha
 
@@ -48,11 +96,36 @@ RSpec.configure do |c|
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
+  # Useless backtrace noise
+  backtrace_exclusion_patterns = [
+    /spec_helper/,
+    /gems/
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+
   c.before(:all) do
     data = YAML.load(default_hiera_config)
     data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
+    end
+  end
+
+  c.before(:each) do
+    if defined?(environment)
+      set_environment(environment)
+    end
+
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
     end
   end
 end


### PR DESCRIPTION
This adds some work that I did to incorporate the declaration of custom
environments and custom hiera.yaml files within any context in a test
suite.

I also added a set of default facts as a safe fallback for most modules.

The code has not been tested in this framework but has worked in the
past.
